### PR TITLE
Updated broken link for WiMos site

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Misc
 ====
 See news and other projects on my [blog][2] 
  
-[1]: http://www.wemos.cc/wiki/doku.php?id=en:d1_mini
+[1]: https://wiki.wemos.cc/products:d1:d1_mini
 [2]: https://hallard.me
 [3]: https://PCBs.io/share/4Q1Z4 
 [4]: http://www.hoperf.com/rf_transceiver/lora/


### PR DESCRIPTION
The WiMos link generates a 404 error - it looks like WeMos have refactored their wiki. This pull request fixes the link to point to the new location for the D1 Mini